### PR TITLE
Fix 'EntryPoints' object has no attribute 'get'

### DIFF
--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -122,7 +122,7 @@ class RelationFactory(object):
 
     @classmethod
     def discover(cls):
-        for ep in entry_points().get('charms.reactive.relation_factory', []):
+        for ep in entry_points().select(group='charms.reactive.relation_factory'):
             factory = ep.load()
             factory.load()
             RelationFactory._factories.append(factory)


### PR DESCRIPTION
Fixes https://github.com/juju-solutions/charms.reactive/issues/237:

```
.tox/unit/lib/python3.12/site-packages/charms/reactive/__init__.py:21: in <module>
    from .relations import *  # noqa
.tox/unit/lib/python3.12/site-packages/charms/reactive/relations.py:944: in <module>
    RelationFactory.discover()
.tox/unit/lib/python3.12/site-packages/charms/reactive/relations.py:125: in discover
    for ep in entry_points().get('charms.reactive.relation_factory', []):
E   AttributeError: 'EntryPoints' object has no attribute 'get'
```